### PR TITLE
Fix Issue #46 : Update sensors at 1 AM

### DIFF
--- a/custom_components/mawaqit/const.py
+++ b/custom_components/mawaqit/const.py
@@ -13,8 +13,6 @@ SENSOR_TYPES = {
     "Isha": "Adhan",
     "Jumua": "Adhan",
     "Jumua 2": "Adhan",
-    #"Aid": "Adhan",
-    #"Aid 2": "Adhan",
     "next_mawaqit": "time",
     "Fajr Iqama": "",  
     "Dhuhr Iqama": "",   
@@ -29,8 +27,6 @@ SENSOR_TYPES = {
     "Mosque_url": "",
     "Mosque_image": "",
 }
-
-
         
 CONF_CALC_METHOD = "calculation_method"
 
@@ -39,8 +35,9 @@ DEFAULT_CALC_METHOD = "nearest"
 
 DATA_UPDATED = "Mawaqit_prayer_data_updated"
 
-CONF_SERVER = "server"
+UPDATE_TIME = (1, 0, 0)
 
+CONF_SERVER = "server"
 
 USERNAME = "user"
 


### PR DESCRIPTION
Issue :
 - Sensors were updated too soon after each prayer, thus automations after a prayer were impossible.
 
Solution :
- Update prayer sensors at 1 AM (and not after each prayer)
- Update Next Salat Time/Preparation/Name 1 minute after each prayer.

Closes #46