### PR TITLE
docs: update README file to include information about installation via HACS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,56 @@
 # A MAWAQIT component for Home Assistant
+
 ## Smart home, Smart mosque : automate things based on prayer times
 
 ٱلسَّلَامُ عَلَيْكُمْ وَرَحْمَةُ ٱللَّٰهِ وَبَرَكَاتُهُ
 
 Essalāmu ʿalaykum wa rahmatu Allahi wa barakatuh
-#
+
 ## English
 
-This component allows you to integrate the data of your mawaqit mosque into HomeAssistant. To do this, a Mawaqit account from **https://mawaqit.net** is required.
+This component allows you to integrate the data of your mawaqit mosque into Home Assistant. To do this, a Mawaqit account from **https://mawaqit.net** is required.
 
-The component is added to HomeAssistant in the form of an integration. For the installation, you must copy the **[custom_components/mawaqit](custom_components/mawaqit)** folder to the _custom_components_ directory of your HomeAssistant installation (create it if it does not exist).
+### Integration installation options
 
-After restarting HomeAssistant, go to _Settings > Devices & Services > Add Integration_ and search for **"Mawaqit"**. Enter the login and password of your **mawaqit.net** account and click on **Submit**. Based on your GPS coordinates (latitude/longitude) stored in HomeAssistant, the component searches for Mawaqit mosques within a radius of 20km around you and asks you to select your preferred mosque.
+The component is added to Home Assistant in the form of an integration. There are two methods to install the integration as mentioned below.
 
-Integration allows you to add 14 components of type ```sensor``` : the 5 prayer times, their associate Iqamas, the Shuruq, the Jumu'a time and a sensor ```sensor.my_mosque``` which summarizes all the data of your mosque (address, website, jumua, iqama, etc...)
+#### With [HACS](https://www.hacs.xyz/)
 
-In the configuration.yaml file, you have an example of code to create automations in HomeAssistant with Mawaqit sensors, in particular to launch the athan at the time of prayer or to launch specific actions (read the Quran, increase the heating 10 minutes before Al-Fajr, open the shutters during shuruq, etc...). The actions are to be adapted according to your HomeAssistant installation.
+If you have HACS installed on your Home Assistant then you can use it to install Mawaqit integration.
 
-#
+* Go to your HACS dashboard, then open the settings (3 dots at the top right corner) and select **Custom Repositories**.
+* Now in **Repository** text field put the URL of this repo: https://github.com/mawaqit/home-assistant
+* In the type field select **Integration**
+* Click **Add** button to finish the setup
 
+#### Manual installation
 
-## Automation examples
+For the manual installation, you must copy the **[custom_components/mawaqit](custom_components/mawaqit)** folder from this repository to the _custom_components_ directory of your Home Assistant installation (create it if it does not exist).
 
-```/config/configuration.yaml```
+### Setup Mawaqit integration
+
+* Restart Home Assistant installation (e.g. From UI go to _Settings > System > Hardware > Power button at top right_)
+* After restarting Home Assistant, go to _Settings > Devices & Services > Add Integration_ and search for **"Mawaqit"**.
+* Enter the login and password of your **mawaqit.net** account and click on **Submit**.
+* Based on your GPS coordinates (latitude/longitude) stored in Home Assistant, the component searches for Mawaqit mosques within a radius of **20km** around you and will ask you to select your **preferred** mosque.
+
+### Components of Mawaqit Integration
+
+Integration allows you to add 14 components of type ```sensor``` :
+
+* The 5 prayer times
+* The Iqama of 5 prayers,
+* The Shuruq
+* The Jumu'a time
+* A sensor ```sensor.my_mosque``` which summarizes all the data of your mosque (address, website, jumua, iqama, etc...)
+
+## Automation Examples
+
+In the `automations.yaml` file, you have an example of code to create automation in Home Assistant with Mawaqit sensors, in particular to launch the athan at the time of prayer or to launch specific actions (read the Quran, increase the heating 10 minutes before Al-Fajr, open the shutters during shuruq, etc...).
+**NOTE**: The actions are to be adapted according to your Home Assistant installation.
+
+* ```/config/configuration.yaml```
+  Make sure that you have time sensor configured in your Home Assistant configuration. In the `automations.yaml` example this sensor is used to make decision when to launch Azan.
 
 ```yaml
 homeassistant:
@@ -31,9 +59,9 @@ sensor:
   display_options:
     - 'time'
     - 'date_time'
-```    
+```
 
-```/config/automations.yaml```
+* ```/config/automations.yaml```
 
 ```yaml
 - id: 'fajr_wakeup'
@@ -74,16 +102,15 @@ sensor:
   initial_state: true
   mode: single
 ```
-#
 
 ## Français
 
-Ce composant permet d'intégrer les données de votre mosquée Mawaqit dans HomeAssistant. Pour ce faire, Un compte Mawaqit **https://mawaqit.net** est nécessaire.
+Ce composant permet d'intégrer les données de votre mosquée Mawaqit dans Home Assistant. Pour ce faire, Un compte Mawaqit **https://mawaqit.net** est nécessaire.
 
-Le composant est rajouté à HomeAssistant sous forme d'une intégration. Pour l'installation, il faut copier le dossier **[custom_components/mawaqit](custom_components/mawaqit)** dans le répertoire _custom_components_ de votre installation HomeAssistant (créez le s'il n'existe pas).
+Le composant est rajouté à Home Assistant sous forme d'une intégration. Pour l'installation, il faut copier le dossier **[custom_components/mawaqit](custom_components/mawaqit)** dans le répertoire _custom_components_ de votre installation Home Assistant (créez le s'il n'existe pas).
 
-Après le redémarrage de HomeAssistant, allez dans _Paramètres > Appareils et Services > Ajouter une intégration_ et cherchez **"Mawaqit"**. Entrez le login et mot de passe de votre compte **mawaqit.net** et cliquez sur **Valider**. En se basant sur vos coordonnées GPS (latitude/longitude) enregistrées dans HomeAssistant, le composant cherche les mosquées Mawaqit dans un rayon de 20 km autour de vous et vous demande de sélectionner votre mosquée préférée.
+Après le redémarrage de Home Assistant, allez dans _Paramètres > Appareils et Services > Ajouter une intégration_ et cherchez **"Mawaqit"**. Entrez le login et mot de passe de votre compte **mawaqit.net** et cliquez sur **Valider**. En se basant sur vos coordonnées GPS (latitude/longitude) enregistrées dans Home Assistant, le composant cherche les mosquées Mawaqit dans un rayon de 20 km autour de vous et vous demande de sélectionner votre mosquée préférée.
 
 L'intégration permet de rajouter 14 composants de type ```sensor``` : les 5 horaires des prières, les iqamas associées, le Shuruq, les horaires de Jumu'a et un sensor ```sensor.my_mosque``` qui résume toutes les données de votre mosquée (adresse, site web, jumua, iqama, etc...).
 
-Dans le fichier configuration.yaml, vous avez un exemple de code pour créer des automatismes dans HomeAssistant avec les sensors Mawaqit notamment pour lancer l'athan à l'heure de la prière ou encore pour lancer des actions spécifiques (lire le Coran, augmenter le chauffage 10 minutes avant Al-Fajr, ouvrir les volets lors du Shuruq etc...). Les actions sont à adapter en fonction de vote installation HomeAssistant.
+Dans le fichier configuration.yaml, vous avez un exemple de code pour créer des automatismes dans Home Assistant avec les sensors Mawaqit notamment pour lancer l'athan à l'heure de la prière ou encore pour lancer des actions spécifiques (lire le Coran, augmenter le chauffage 10 minutes avant Al-Fajr, ouvrir les volets lors du Shuruq etc...). Les actions sont à adapter en fonction de vote installation Home Assistant.


### PR DESCRIPTION

Hi,
I have made some changes to the README file to basically guide users on installation via HACS as another option in addition to manual installation.
I have not updated the French section currently as I'm not familiar with the language. But I can provide ChatGPT translation to the PR.
Please let me know if further changes are required in the PR. 
Thank you.

The summary of the changes is:
* The README now contains the information on how to get the integration via HACS inside Home Assistant.

* The heading are also organized to divide the documentation into sections.

* The installation steps are now organized as individual point for better reading.

TODOs:

- [ ]  Update French section of the documentation